### PR TITLE
Feature/qemu cpu models support

### DIFF
--- a/Platforms/QemuQ35Pkg/CpuInfoDxe/CpuInfoDxe.c
+++ b/Platforms/QemuQ35Pkg/CpuInfoDxe/CpuInfoDxe.c
@@ -1,0 +1,129 @@
+/** @file CpuInfoDxe.c
+
+    Copyright (c) Microsoft Corporation. All rights reserved.
+
+    Driver that prints CPU branding information
+**/
+
+#include <Uefi.h>
+#include <Library/UefiLib.h>
+#include <Library/DebugLib.h>
+#include <Library/UefiDriverEntryPoint.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/BaseLib.h>
+#include <Library/PrintLib.h>
+#include <Library/UefiCpuLib.h>
+
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    UINT32    SteppingId       : 4; ///< [Bits   3:0] Stepping ID
+    UINT32    Model            : 4; ///< [Bits   7:4] Model
+    UINT32    FamilyId         : 4; ///< [Bits  11:8] Family
+    UINT32    ProcessorType    : 2; ///< [Bits 13:12] Processor Type
+    UINT32    Reserved1        : 2; ///< [Bits 15:14] Reserved
+    UINT32    ExtendedModelId  : 4; ///< [Bits 19:16] Extended Model ID
+    UINT32    ExtendedFamilyId : 8; ///< [Bits 27:20] Extended Family ID
+    UINT32    Reserved2        : 4; ///< Reserved
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32    Uint32;
+} CPUID_VERSION_INFO_EAX;
+
+#define CPUID_VERSION_INFO   0x01
+#define CPUID_BRAND_STRING1  0x80000002
+#define CPUID_BRAND_STRING2  0x80000003
+#define CPUID_BRAND_STRING3  0x80000004
+#define MAX_MESSAGE_LENGTH   64
+
+STATIC CHAR8  mMessage[MAX_MESSAGE_LENGTH];
+
+CHAR8 *
+EFIAPI
+GetCpuBrandString (
+  )
+{
+  // Needed length check, 3 CPUID calls with 4 DWORDs of chars and a NULL termination
+  if (MAX_MESSAGE_LENGTH < ((3 * 4 * 4) + 1)) {
+    ASSERT (FALSE);
+    return NULL;
+  }
+
+  // Update CPUID data (ASCII chars) directly into mMessage buffer
+  AsmCpuid (CPUID_BRAND_STRING1, (UINT32 *)&(mMessage[0x00]), (UINT32 *)&(mMessage[0x04]), (UINT32 *)&(mMessage[0x08]), (UINT32 *)&(mMessage[0x0C]));
+  AsmCpuid (CPUID_BRAND_STRING2, (UINT32 *)&(mMessage[0x10]), (UINT32 *)&(mMessage[0x14]), (UINT32 *)&(mMessage[0x18]), (UINT32 *)&(mMessage[0x1C]));
+  AsmCpuid (CPUID_BRAND_STRING3, (UINT32 *)&(mMessage[0x20]), (UINT32 *)&(mMessage[0x24]), (UINT32 *)&(mMessage[0x28]), (UINT32 *)&(mMessage[0x2C]));
+
+  // Make sure mMessage is terminated and return
+  mMessage[0x30] = 0x00;
+  return mMessage;
+}
+
+CHAR8 *
+EFIAPI
+GetCpuIdFamiyEaxString (
+  )
+{
+  UINT32  RegEax;
+  UINTN   Len;
+
+  AsmCpuid (CPUID_VERSION_INFO, &RegEax, NULL, NULL, NULL);
+
+  Len = AsciiSPrint (mMessage, MAX_MESSAGE_LENGTH, "0x%08x", RegEax);
+  return ((Len == 0) ? NULL : mMessage);
+}
+
+UINT8
+EFIAPI
+GetCpuSteppingId (
+  VOID
+  )
+{
+  CPUID_VERSION_INFO_EAX  Eax;
+
+  AsmCpuid (CPUID_VERSION_INFO, &Eax.Uint32, NULL, NULL, NULL);
+
+  return (UINT8)Eax.Bits.SteppingId;
+}
+
+UINT32
+EFIAPI
+GetCpuFamilyModel (
+  VOID
+  )
+{
+  CPUID_VERSION_INFO_EAX  Eax;
+
+  AsmCpuid (CPUID_VERSION_INFO, &Eax.Uint32, NULL, NULL, NULL);
+
+  //
+  // Mask other fields than Family and Model.
+  //
+  Eax.Bits.SteppingId    = 0;
+  Eax.Bits.ProcessorType = 0;
+  Eax.Bits.Reserved1     = 0;
+  Eax.Bits.Reserved2     = 0;
+  return Eax.Uint32;
+}
+
+/**
+   Dxe Entry Point
+**/
+EFI_STATUS
+EFIAPI
+CpuInfoDxeEntryPoint (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  DEBUG ((DEBUG_INFO, "[%a] - Entry\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "\tCPU Brand Name: %a\n", GetCpuBrandString ()));
+  DEBUG ((DEBUG_INFO, "\tFamily Id: %x\n", GetCpuIdFamiyEaxString ()));
+  DEBUG ((DEBUG_INFO, "\tStepping: %x\n", GetCpuSteppingId ()));
+  DEBUG ((DEBUG_INFO, "\tModel Id: %x\n", GetCpuFamilyModel ()));
+  return EFI_SUCCESS;
+}

--- a/Platforms/QemuQ35Pkg/CpuInfoDxe/CpuInfoDxe.inf
+++ b/Platforms/QemuQ35Pkg/CpuInfoDxe/CpuInfoDxe.inf
@@ -1,0 +1,35 @@
+## @file CpuInfoDxe.inf
+#
+# Cpu Info Debug Dxe
+#
+#Copyright (c) Microsoft Corportaion. All rights reserved.
+#
+##
+
+[Defines]
+   INF_VERSION       = 1.27
+   BASE_NAME         = CpuInfoDxe
+   FILE_GUID         = F5E4F8D3-9975-4263-8BB5-67178988429E
+   VERSION_STRING    = 1.0
+   MODULE_TYPE       = DXE_DRIVER
+   ENTRY_POINT       = CpuInfoDxeEntryPoint
+
+[Sources]
+  CpuInfoDxe.c 
+
+[Packages]
+  MdePkg/MdePkg.dec
+  QemuQ35Pkg/QemuQ35Pkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  UefiCpuPkg/UefiCpuPkg.dec
+
+[LibraryClasses]
+  DebugLib
+  UefiLib
+  BaseLib
+  PrintLib
+  UefiDriverEntryPoint
+  UefiBootServicesTableLib
+
+[Depex]
+  TRUE

--- a/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
@@ -105,16 +105,13 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
         else:
             args += " -m 2048"
 
-        # TODO: Add more documentation
         cpu_model = env.GetValue("CPU_MODEL")
         if cpu_model is None:
             cpu_model = "qemu64"
 
         logging.log(logging.INFO, "CPU model: " + cpu_model)
 
-        # TODO: Remove these comments
         #args += " -cpu qemu64,+rdrand,umip,+smep,+popcnt" # most compatible x64 CPU model + RDRAND + UMIP + SMEP +POPCNT support (not included by default)
-        # args += " -cpu qemu64,rdrand=on,umip=on,smep=on,pdpe1gb=on,popcnt=on" # most compatible x64 CPU model + RDRAND + UMIP + SMEP + PDPE1GB + POPCNT support (not included by default)
         cpu_arg = " -cpu " + cpu_model + ",rdrand=on,umip=on,smep=on,pdpe1gb=on,popcnt=on"
         args += cpu_arg
 

--- a/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
@@ -105,8 +105,18 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
         else:
             args += " -m 2048"
 
+        # TODO: Add more documentation
+        cpu_model = env.GetValue("CPU_MODEL")
+        if cpu_model is None:
+            cpu_model = "qemu64"
+
+        logging.log(logging.INFO, "CPU model: " + cpu_model)
+
+        # TODO: Remove these comments
         #args += " -cpu qemu64,+rdrand,umip,+smep,+popcnt" # most compatible x64 CPU model + RDRAND + UMIP + SMEP +POPCNT support (not included by default)
-        args += " -cpu qemu64,rdrand=on,umip=on,smep=on,pdpe1gb=on,popcnt=on" # most compatible x64 CPU model + RDRAND + UMIP + SMEP + PDPE1GB + POPCNT support (not included by default)
+        # args += " -cpu qemu64,rdrand=on,umip=on,smep=on,pdpe1gb=on,popcnt=on" # most compatible x64 CPU model + RDRAND + UMIP + SMEP + PDPE1GB + POPCNT support (not included by default)
+        cpu_arg = " -cpu " + cpu_model + ",rdrand=on,umip=on,smep=on,pdpe1gb=on,popcnt=on"
+        args += cpu_arg
 
         if env.GetBuildValue ("QEMU_CORE_NUM") is not None:
             args += " -smp " + env.GetBuildValue ("QEMU_CORE_NUM")

--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
@@ -1081,6 +1081,9 @@ QemuQ35Pkg/Library/ResetSystemLib/StandaloneMmResetSystemLib.inf
 
   MdeModulePkg/Core/RuntimeDxe/RuntimeDxe.inf
 
+  # CPU branding information
+  QemuQ35Pkg/CpuInfoDxe/CpuInfoDxe.inf
+
   MdeModulePkg/Universal/SecurityStubDxe/SecurityStubDxe.inf {
     <LibraryClasses>
       NULL|SecurityPkg/Library/DxeImageVerificationLib/DxeImageVerificationLib.inf

--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.fdf
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.fdf
@@ -330,6 +330,9 @@ INF  MdeModulePkg/Universal/ResetSystemRuntimeDxe/ResetSystemRuntimeDxe.inf
 INF  MdeModulePkg/Universal/Metronome/Metronome.inf
 INF  PcAtChipsetPkg/PcatRealTimeClockRuntimeDxe/PcatRealTimeClockRuntimeDxe.inf
 
+# CPU branding information
+INF  QemuQ35Pkg/CpuInfoDxe/CpuInfoDxe.inf
+
 INF  QemuPkg/VirtioPciDeviceDxe/VirtioPciDeviceDxe.inf
 INF  QemuPkg/Virtio10Dxe/Virtio10.inf
 INF  QemuPkg/VirtioBlkDxe/VirtioBlk.inf


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description
Added CpuInfoDxe driver that prints the basic information about the CPU model invoked by QEMU.
Added a command line argument to pass the CPU model to be used while invoking QEMU
Added basic tests to validate the CPU model being used

- [ ] Impacts functionality?
Added a new driver that prints CPU model information

- [ ] Impacts security?
N/A

- [ ] Breaking change?
No

- [ ] Includes tests?
No

- [ ] Includes documentation?
No

## How This Was Tested
Validated the changes on QEMU

## Integration Instructions
N/A